### PR TITLE
Add parameterless constructors for resource logging

### DIFF
--- a/FAT/Runtime/Activity/ActivityWeeklyTask/ActivityWeeklyTask.cs
+++ b/FAT/Runtime/Activity/ActivityWeeklyTask/ActivityWeeklyTask.cs
@@ -44,6 +44,9 @@ namespace FAT
         public override ActivityVisual Visual => VisualMain.visual;
         private List<int> phaseCompleteList = new List<int>();
 
+        public ActivityWeeklyTask() { }
+
+
         public ActivityWeeklyTask(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/BP/BPActivity.cs
+++ b/FAT/Runtime/Activity/BP/BPActivity.cs
@@ -35,6 +35,9 @@ namespace FAT
             return Game.Manager.configMan.GetBpDetailConfig(_detailId);
         }
         
+        public BPActivity() { }
+
+        
         public BPActivity(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Castle/ActivityCastle.cs
+++ b/FAT/Runtime/Activity/Castle/ActivityCastle.cs
@@ -40,6 +40,9 @@ namespace FAT
         private int hasPopup;
         private readonly OutputSpawnBonusHandler bonusHandler = new();
 
+        public ActivityCastle() { }
+
+
         public ActivityCastle(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/ClawOrder/ActivityClawOrder.cs
+++ b/FAT/Runtime/Activity/ClawOrder/ActivityClawOrder.cs
@@ -85,6 +85,10 @@ namespace FAT
         private Dictionary<int, OrderData> _recordedOrderMap = new();
 
 
+        public ActivityClawOrder() { }
+
+
+
         public ActivityClawOrder(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Entity/ActivityExtraRewardOrder.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityExtraRewardOrder.cs
@@ -41,6 +41,8 @@ namespace FAT
 
         private long lifeTime => ConfD.Lifetime;
         private int actEndTime;
+        public ActivityExtraRewardOrder() { }
+
         public ActivityExtraRewardOrder(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Entity/ActivityFlashOrder.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityFlashOrder.cs
@@ -103,6 +103,9 @@ namespace FAT
             }
         }
 
+        public ActivityFlashOrder() { }
+
+
         public ActivityFlashOrder(ActivityLite lite_) {
             Lite = lite_;
             confD = Game.Manager.configMan.GetEventFlashOrderConfig(lite_.Param);

--- a/FAT/Runtime/Activity/Entity/ActivityInvite.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityInvite.cs
@@ -33,6 +33,9 @@ namespace FAT {
             acti.UpdateValue(acti.value + 1);
         }
 
+        public ActivityInvite() { }
+
+
         public ActivityInvite(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventInvite(lite_.Param);

--- a/FAT/Runtime/Activity/Entity/ActivityMIG.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityMIG.cs
@@ -14,6 +14,9 @@ namespace FAT {
         public UIResAlt Res { get; } = new(UIConfig.UINoticeMIG);
         public PopupActivity Popup { get; internal set; }
 
+        public ActivityMIG() { }
+
+
         public ActivityMIG(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventMarketIAPGift(lite_.Param);

--- a/FAT/Runtime/Activity/Entity/ActivityMagicHour.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityMagicHour.cs
@@ -19,6 +19,9 @@ namespace FAT {
         // 等待激活的星想事成slot
         private Dictionary<int, (int reqNum, int realDffy)> waitingMagicHourSlots = new();
 
+        public ActivityMagicHour() { }
+
+
         public ActivityMagicHour(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventWishing(lite_.Param);

--- a/FAT/Runtime/Activity/Entity/ActivityScore.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityScore.cs
@@ -109,6 +109,9 @@ namespace FAT
             }
         }
 
+        public ActivityScore() { }
+
+
         public ActivityScore(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Entity/ActivityStep.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityStep.cs
@@ -39,6 +39,9 @@ namespace FAT {
         public int DecorateScore => confG.DecorateScore;
         private readonly OutputSpawnBonusHandler bonusHandler = new();
 
+        public ActivityStep() { }
+
+
         public ActivityStep(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventStep(lite_.Param);

--- a/FAT/Runtime/Activity/Entity/ActivitySurvey.cs
+++ b/FAT/Runtime/Activity/Entity/ActivitySurvey.cs
@@ -21,6 +21,9 @@ namespace FAT {
         public PopupActivity Popup { get; internal set; }
         public RewardConfig SurveyReward { get; private set; }
 
+        public ActivitySurvey() { }
+
+
         public ActivitySurvey(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventSurvey(lite_.Param);

--- a/FAT/Runtime/Activity/Entity/ActivityTreasure.cs
+++ b/FAT/Runtime/Activity/Entity/ActivityTreasure.cs
@@ -131,6 +131,9 @@ namespace FAT
         private List<RewardCommitData> scoreCommitRewardList = new(); //积分兑换钥匙循环中：所有积分奖励对应的CommitData 待提交的积分奖励
         private List<RewardCommitData> tempRewardList = new();
 
+        public ActivityTreasure() { }
+
+
         public ActivityTreasure(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Entity/OrderDash/ActivityOrderDash.cs
+++ b/FAT/Runtime/Activity/Entity/OrderDash/ActivityOrderDash.cs
@@ -108,6 +108,9 @@ namespace FAT
             return slotId == list[orderIndex];
         }
 
+        public ActivityOrderDash() { }
+
+
         public ActivityOrderDash(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventOrderDash(lite_.Param);

--- a/FAT/Runtime/Activity/Farm/FarmBoardActivity.cs
+++ b/FAT/Runtime/Activity/Farm/FarmBoardActivity.cs
@@ -49,6 +49,9 @@ namespace FAT
             _ClearFarmBoardData();
         }
         
+        public FarmBoardActivity() { }
+
+        
         public FarmBoardActivity(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Fish/ActivityFishing.cs
+++ b/FAT/Runtime/Activity/Fish/ActivityFishing.cs
@@ -104,6 +104,9 @@ namespace FAT
         // 已解锁的鱼
         private readonly HashSet<int> _fishUnlockSet = new();
 
+        public ActivityFishing() { }
+
+
         public ActivityFishing(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/OrderLike/ActivityOrderLike.cs
+++ b/FAT/Runtime/Activity/OrderLike/ActivityOrderLike.cs
@@ -57,6 +57,9 @@ namespace FAT
         private EventOrderLikeDetail _confDetail;
         private EventTheme _mainTheme;
 
+        public ActivityOrderLike() { }
+
+
         public ActivityOrderLike(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/Ranking/ActivityRanking.cs
+++ b/FAT/Runtime/Activity/Ranking/ActivityRanking.cs
@@ -93,6 +93,8 @@ namespace FAT
         }
 
         public UIResAlt MainRes = new(UIConfig.UIActivityRankMilestoneReward);
+        public ActivityRanking() { }
+
         public ActivityRanking(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/RedeemShop/ActivityRedeemShopLike.cs
+++ b/FAT/Runtime/Activity/RedeemShop/ActivityRedeemShopLike.cs
@@ -112,6 +112,8 @@ namespace FAT
         private EventRedeemMilestone _curShowMilestoneConfig;
         private RedeemShopSpawnBonusHandler _spawnBonusHandler;
         public List<MliestoneNodeItem> ClonMilestoneNodeList = new();
+        public ActivityRedeemShopLike() { }
+
         public ActivityRedeemShopLike(ActivityLite lite)
         {
             Lite = lite;

--- a/FAT/Runtime/Activity/ThreeSign/ActivityThreeSign.cs
+++ b/FAT/Runtime/Activity/ThreeSign/ActivityThreeSign.cs
@@ -38,6 +38,9 @@ namespace FAT
         //记录弹脸时要传入的奖励数据
         private PoolMapping.Ref<List<RewardCommitData>> signReward;
         
+        public ActivityThreeSign() { }
+
+        
         public ActivityThreeSign(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/WeeklyRaffle/ActivityWeeklyRaffle.cs
+++ b/FAT/Runtime/Activity/WeeklyRaffle/ActivityWeeklyRaffle.cs
@@ -77,6 +77,8 @@ namespace FAT
         #endregion
 
         #region 活动基础
+        public ActivityWeeklyRaffle() { }
+
         public ActivityWeeklyRaffle(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/Activity/WishBoard/WishBoardActivity.cs
+++ b/FAT/Runtime/Activity/WishBoard/WishBoardActivity.cs
@@ -49,6 +49,9 @@ namespace FAT
         public TokenOutputType OutputType { get; private set; } = TokenOutputType.None;
         public override ActivityVisual Visual => VisualStartNoticePopup.visual;
 
+        public WishBoardActivity() { }
+
+
         public WishBoardActivity(ActivityLite lite)
         {
             Lite = lite;

--- a/FAT/Runtime/ActivityBingo/ActivityBingo.cs
+++ b/FAT/Runtime/ActivityBingo/ActivityBingo.cs
@@ -184,6 +184,10 @@ namespace FAT
         }
 
 
+        public ActivityBingo() { }
+
+
+
         public ActivityBingo(ActivityLite lite)
         {
             Lite = lite;

--- a/FAT/Runtime/ActivityBingoTask/ActivityBingoTask.cs
+++ b/FAT/Runtime/ActivityBingoTask/ActivityBingoTask.cs
@@ -37,6 +37,8 @@ namespace FAT
         #endregion
 
         #region ActivityLike
+        public ActivityBingoTask() { }
+
         public ActivityBingoTask(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityDigging/Entity/ActivityDigging.cs
+++ b/FAT/Runtime/ActivityDigging/Entity/ActivityDigging.cs
@@ -124,6 +124,9 @@ namespace FAT
         public override ActivityVisual Visual => VisualPanel;
         private DiggingSpawnBonusHandler spawnBonusHandler;
 
+        public ActivityDigging() { }
+
+
         public ActivityDigging(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityDuel/ActivityDuel.cs
+++ b/FAT/Runtime/ActivityDuel/ActivityDuel.cs
@@ -76,6 +76,10 @@ namespace FAT
         public PopupDuelStart StartPopup;
 
 
+        public ActivityDuel() { }
+
+
+
         public ActivityDuel(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/Pack1in3.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/Pack1in3.cs
@@ -30,6 +30,9 @@ namespace FAT {
         public override int StockTotal => 1;
         public bool Sale => confD.Sale;
 
+        public Pack1in3() { }
+
+
         public Pack1in3(ActivityLite lite_) {
             Lite = lite_;
             confD = GetThreeForOnePack(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackDaily.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackDaily.cs
@@ -23,6 +23,9 @@ namespace FAT {
             return (r, r ? "not ready by config" : null);
         }
 
+        public PackDaily() { }
+
+
         public PackDaily(ActivityLite lite_) {
             Lite = lite_;
             confD = GetDailyPopPack(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackEndless.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackEndless.cs
@@ -89,6 +89,9 @@ namespace FAT {
         public override int StockTotal => -1;    //限购次数默认设成-1次 代表可以无限购买
         public override bool Valid => _curRecIndex >= 0 && _curRecIndex <= _totalIndex;
 
+        public PackEndless() { }
+
+
         public PackEndless(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackEndlessFarm.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackEndlessFarm.cs
@@ -82,6 +82,9 @@ namespace FAT {
         public override int StockTotal => -1;    //限购次数默认设成-1次 代表可以无限购买
         public override bool Valid => _curRecIndex >= 0 && _curRecIndex <= _totalIndex;
 
+        public PackEndlessFarm() { }
+
+
         public PackEndlessFarm(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackEndlessThree.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackEndlessThree.cs
@@ -99,6 +99,9 @@ namespace FAT {
         public override int StockTotal => -1;    //限购次数默认设成-1次 代表可以无限购买
         public override bool Valid => _curRecIndex >= 0 && _curRecIndex <= _totalIndex;
 
+        public PackEndlessThree() { }
+
+
         public PackEndlessThree(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackEndlessWishBoard.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackEndlessWishBoard.cs
@@ -81,6 +81,9 @@ namespace FAT
         public override int StockTotal => -1;    //限购次数默认设成-1次 代表可以无限购买
         public override bool Valid => _curRecIndex >= 0 && _curRecIndex <= _totalIndex;
 
+        public PackEndlessWishBoard() { }
+
+
         public PackEndlessWishBoard(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackEnergy.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackEnergy.cs
@@ -22,6 +22,9 @@ namespace FAT
         public bool UseAPI => confD.IsApiUse;
         public string ModelVersion => confD.ModelVersion;
 
+        public PackEnergy() { }
+
+
         public PackEnergy(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackEnergyMultiPack.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackEnergyMultiPack.cs
@@ -26,6 +26,9 @@ namespace FAT
 
         private readonly List<int> _packList = new();
 
+        public PackEnergyMultiPack() { }
+
+
         public PackEnergyMultiPack(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackErgList.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackErgList.cs
@@ -46,6 +46,9 @@ namespace FAT {
             return GetErgListDetail(_detailId);
         }
         
+        public PackErgList() { }
+
+        
         public PackErgList(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackGemEndlessThree.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackGemEndlessThree.cs
@@ -109,6 +109,9 @@ namespace FAT
         public override int StockTotal => -1;    //限购次数默认设成-1次 代表可以无限购买
         public override bool Valid => _curRecIndex >= 0 && _curRecIndex <= _totalIndex;
 
+        public PackGemEndlessThree() { }
+
+
         public PackGemEndlessThree(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackGemThreeForOne.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackGemThreeForOne.cs
@@ -55,6 +55,9 @@ namespace FAT
         private readonly int _saveDataBeginId = 4;
         private int _packEndTime;
 
+        public PackGemThreeForOne() { }
+
+
         public PackGemThreeForOne(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackMarketSlide.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackMarketSlide.cs
@@ -47,6 +47,9 @@ namespace FAT {
         public override int ThemeId { get; }
         public override int StockTotal => -1;   //设成-1 避免此字段的影响
         
+        public PackMarketSlide() { }
+
+        
         public PackMarketSlide(ActivityLite lite_) {
             Lite = lite_;
             confD = GetMarketSlidePack(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackNewSession.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackNewSession.cs
@@ -16,6 +16,9 @@ namespace FAT {
             return (r, r ? "not ready by config" : null);
         }
 
+        public PackNewSession() { }
+
+
         public PackNewSession(ActivityLite lite_) {
             Lite = lite_;
             confD = GetNewSessionPack(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusOne.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusOne.cs
@@ -22,6 +22,9 @@ namespace FAT {
         private int _freeGrpId = 0;     //礼包中的赠品id
         private bool _hasBuy = false;    //记录是否已经购买过礼包 用于区别是否为重复购买
 
+        public PackOnePlusOne() { }
+
+
         public PackOnePlusOne(ActivityLite lite_) {
             Lite = lite_;
             confD = GetOnePlusOne(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusOneFight.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusOneFight.cs
@@ -28,6 +28,9 @@ namespace FAT
         private int _freeGrpId = 0;     //礼包中的赠品id
         private bool _hasBuy = false;    //记录是否已经购买过礼包 用于区别是否为重复购买
 
+        public PackOnePlusOneFight() { }
+
+
         public PackOnePlusOneFight(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusOneMine.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusOneMine.cs
@@ -22,6 +22,9 @@ namespace FAT {
         private int _freeGrpId = 0;     //礼包中的赠品id
         private bool _hasBuy = false;    //记录是否已经购买过礼包 用于区别是否为重复购买
 
+        public PackOnePlusOneMine() { }
+
+
         public PackOnePlusOneMine(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventMineOnePlusOne(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusTwo.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackOnePlusTwo.cs
@@ -26,6 +26,9 @@ namespace FAT {
         private int _freeGrpId2 = 0;     //礼包中的第二列赠品id
         private bool _hasBuy = false;    //记录是否已经购买过礼包 用于区别是否为重复购买
 
+        public PackOnePlusTwo() { }
+
+
         public PackOnePlusTwo(ActivityLite lite_) {
             Lite = lite_;
             confD = GetOnePlusTwo(lite_.Param);

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackProgress.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackProgress.cs
@@ -41,6 +41,9 @@ namespace FAT
         public override int StockTotal => 3;
         public override UIResAlt Res { get; } = new(UIConfig.UIPackProgress);
 
+        public PackProgress() { }
+
+
         public PackProgress(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackRetention.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackRetention.cs
@@ -34,6 +34,8 @@ namespace FAT
         private int _nextCollectTs = 0;     //下一个可领取的免费奖励时间戳
         private Entry _entry;
         private bool _willEnd = false;
+        public PackRetention() { }
+
         public PackRetention(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackShinnyGuar.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackShinnyGuar.cs
@@ -29,6 +29,9 @@ namespace FAT
             return (r, r ? "not ready by config" : null);
         }
         
+        public PackShinnyGuar() { }
+
+        
         public PackShinnyGuar(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackSpin.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackSpin.cs
@@ -44,6 +44,8 @@ namespace FAT
             e.dot.SetActive(_freeChanceCount > 0);
             return null;
         }
+        public PackSpin() { }
+
         public PackSpin(ActivityLite lite)
         {
             Lite = lite;

--- a/FAT/Runtime/ActivityLoginGift/LoginGiftActivity.cs
+++ b/FAT/Runtime/ActivityLoginGift/LoginGiftActivity.cs
@@ -17,6 +17,9 @@ namespace FAT
         public override bool Valid => confD != null;
         public PopupActivity Popup { get; internal set; }
 
+        public LoginGiftActivity() { }
+
+
         public LoginGiftActivity(ActivityLite lite_) {
             Lite = lite_;
             confD = GetEventLoginGift(lite_.Param);

--- a/FAT/Runtime/ActivityOrderBonus/ActivityOrderBonus.cs
+++ b/FAT/Runtime/ActivityOrderBonus/ActivityOrderBonus.cs
@@ -41,6 +41,8 @@ namespace FAT
         #endregion
 
         #region ActivityLike
+        public ActivityOrderBonus() { }
+
         public ActivityOrderBonus(ActivityLite activityLite)
         {
             Lite = activityLite;

--- a/FAT/Runtime/ActivityOrderChallenge/Entity/ActivityOrderChallenge.cs
+++ b/FAT/Runtime/ActivityOrderChallenge/Entity/ActivityOrderChallenge.cs
@@ -76,6 +76,9 @@ namespace FAT
         private bool isOrderSuccess;
         private bool isOrderFail;
 
+        public ActivityOrderChallenge() { }
+
+
         public ActivityOrderChallenge(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityOrderRate/ActivityOrderRate.cs
+++ b/FAT/Runtime/ActivityOrderRate/ActivityOrderRate.cs
@@ -50,6 +50,9 @@ namespace FAT
         private readonly List<int> _milestoneList = new();
         #endregion
 
+        public ActivityOrderRate() { }
+
+
         public ActivityOrderRate(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityOrderStreak/ActivityOrderStreak.cs
+++ b/FAT/Runtime/ActivityOrderStreak/ActivityOrderStreak.cs
@@ -40,6 +40,9 @@ namespace FAT
 
         public override ActivityVisual Visual => VisualRes.visual;
 
+        public ActivityOrderStreak() { }
+
+
         public ActivityOrderStreak(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/ActivityRace/ActivityRace.cs
+++ b/FAT/Runtime/ActivityRace/ActivityRace.cs
@@ -232,6 +232,9 @@ namespace FAT
             RaceManager.GetInstance().SetActivity(null);
         }
 
+        public ActivityRace() { }
+
+
         public ActivityRace(ActivityLite lite)
         {
             Lite = lite;

--- a/FAT/Runtime/ActivityStamp/ActivityStamp.cs
+++ b/FAT/Runtime/ActivityStamp/ActivityStamp.cs
@@ -29,6 +29,9 @@ namespace FAT {
         private int _curFinishIndex = 0;  //当前轮次中已经完成到的序号,默认从0开始,代表一个也没完成,之后每完成一个+1
         private bool _ignorePopup;
 
+        public ActivityStamp() { }
+
+
         public ActivityStamp(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/BoardActivity/FightBoard/FightBoardActivity.cs
+++ b/FAT/Runtime/BoardActivity/FightBoard/FightBoardActivity.cs
@@ -109,6 +109,8 @@ namespace FAT
         #endregion
 
         #region ActivityLike
+        public FightBoardActivity() { }
+
         public FightBoardActivity(ActivityLite lite)
         {
             Lite = lite;

--- a/FAT/Runtime/PackDiscount/PackDiscount.cs
+++ b/FAT/Runtime/PackDiscount/PackDiscount.cs
@@ -29,6 +29,9 @@ namespace FAT
         private int tokenPhase;
         public int TokenPrev { get; private set; }
 
+        public PackDiscount() { }
+
+
         public PackDiscount(ActivityLite lite_)
         {
             Lite = lite_;

--- a/FAT/Runtime/UI/Misc/Setting/Community/CommunityMailActivity.cs
+++ b/FAT/Runtime/UI/Misc/Setting/Community/CommunityMailActivity.cs
@@ -17,6 +17,8 @@ namespace FAT
         public VisualPopup VisualUICommunityMailStartNotice { get; } = new(UIConfig.UICommunityMailStartNotice);
         public override ActivityVisual Visual => VisualUICommunityMailStartNotice.visual;
         private int _popupCount;
+        public CommunityMailActivity() { }
+
         public CommunityMailActivity(ActivityLite lite)
         {
             Lite = lite;


### PR DESCRIPTION
## Summary
- add public parameterless constructors to activity and pack classes referenced by `FishResourceLogger` so they can be instantiated for resource name collection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad19282e7c8320a77e7ad744721fe3