### PR TITLE
Add missing event type mappings

### DIFF
--- a/FAT/Editor/Resource/FishResourceLogger.cs
+++ b/FAT/Editor/Resource/FishResourceLogger.cs
@@ -80,6 +80,15 @@ namespace FAT
             { EventType.WishEndlessPack, typeof(PackEndlessWishBoard) },
             { EventType.SpinPack, typeof(PackSpin) },
             { EventType.Bp, typeof(BPActivity) },
+            { EventType.NewUser, typeof(PackNU) },
+            { EventType.ToolExchange, typeof(ExchangeTool) },
+            { EventType.De, typeof(ActivityDE) },
+            { EventType.Dem, typeof(ActivityDEM) },
+            { EventType.CardAlbum, typeof(CardActivity) },
+            { EventType.Decorate, typeof(DecorateActivity) },
+            { EventType.MiniBoard, typeof(MiniBoardActivity) },
+            { EventType.Pachinko, typeof(ActivityPachinko) },
+            { EventType.MiniBoardMulti, typeof(MiniBoardMultiActivity) },
         };
         
         private static readonly HashSet<string> _ArtExtensions = new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- link additional EventType entries to their ActivityLike implementations in FishResourceLogger

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad260c10108320b7333e2e9e20dd20