### PR TITLE
Add parameterless constructors for resource logger initialization

### DIFF
--- a/FAT/Runtime/Activity/Entity/ExchangeTool.cs
+++ b/FAT/Runtime/Activity/Entity/ExchangeTool.cs
@@ -19,6 +19,8 @@ namespace FAT {
         public bool WillEnd => Stock == 0;
         public readonly List<Config.RewardConfig> goods = new();
 
+        public ExchangeTool() { }
+
         public ExchangeTool(ToolExchange conf_) {
             conf = conf_;
             var ts = Game.UtcNow;

--- a/FAT/Runtime/ActivityGiftPack/Entity/PackNU.cs
+++ b/FAT/Runtime/ActivityGiftPack/Entity/PackNU.cs
@@ -12,6 +12,8 @@ namespace FAT {
         public override UIResAlt Res { get; } = new(UIConfig.UIGiftPackNU);
         public override int StockTotal => conf.Paytimes;
 
+        public PackNU() { }
+
         public PackNU(NewUserPack conf_) {
             conf = conf_;
             var ts = Game.UtcNow;

--- a/FAT/Runtime/ActivityPachinko/ActivityPachinko.cs
+++ b/FAT/Runtime/ActivityPachinko/ActivityPachinko.cs
@@ -132,6 +132,8 @@ namespace FAT
 
         #region 通用逻辑
 
+        public ActivityPachinko() { }
+
         public ActivityPachinko(ActivityLite lite)
         {
             Lite = lite;


### PR DESCRIPTION
## Summary
- Add missing parameterless constructors in `PackNU`, `ExchangeTool`, and `ActivityPachinko` to support reflection-based instantiation in `FishResourceLogger`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3726faa883209eabde84121a2dd3